### PR TITLE
Resolves #2: command to show roles, and respective subjects

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ hubot auth assign `subject` `role` | `auth.assign` | Assigns `subject` to `role`
 hubot auth unassign `subject` `role` | `auth.unassign` | Unassigns `subject` from `role`.
 hubot auth default `role` | `auth.default` | Changes the default `role` for unassigned subjects.
 hubot auth ids | `auth.ids` | Returns a list of listener IDs that can be blocked.
+hubot auth roles | `auth.roles` | Returns a list of roles, and their respective subjects.
 
 
 ## Sample Interaction

--- a/src/rbac.coffee
+++ b/src/rbac.coffee
@@ -12,10 +12,12 @@
 #   hubot auth unassign <subject> <role> - Unassigns <subject> from <role>.
 #   hubot auth default <role> - Changes the default <role> for unassigned subjects.
 #   hubot auth ids - Returns a list of listener IDs that can be blocked.
+#   hubot auth roles - Returns a list of roles, and their respective subjects.
 #
 # Notes:
 #   WIP
 #   May add support for RegEx blocking
+#   Case-sensitivity
 #
 # Author:
 #   MrSaints
@@ -143,6 +145,21 @@ module.exports = (robot) ->
         ids = (listener.options.id for listener in robot.listeners when listener.options.id?)
         robot.logger.debug "hubot-rbac: #{ids}"
         res.send "Available listener IDs: #{ids.join(", ")}"
+
+    robot.respond /auth roles/i, id: "auth.roles", (res) ->
+        response = {}
+        noResults = true
+
+        _subjects.forEach (roles, subject) ->
+            roles.forEach (role) ->
+                response[role] or= []
+                response[role].push subject
+
+        for role, subjects of response
+            res.send "#{role}: #{subjects.join(", ")}"
+            noResults = false
+
+        return res.reply "There are no assigned roles." if noResults
 
     robot.listenerMiddleware (context, next, done) ->
         lid = context.listener.options.id

--- a/test/rbac-test.coffee
+++ b/test/rbac-test.coffee
@@ -24,6 +24,7 @@ describe "rbac", ->
     expect(@robot.respond).to.have.been.calledWith(/auth unassign (.+) (.+)/i)
     expect(@robot.respond).to.have.been.calledWith(/auth default (.+)/i)
     expect(@robot.respond).to.have.been.calledWith(/auth ids/i)
+    expect(@robot.respond).to.have.been.calledWith(/auth roles/i)
 
   it "registers a listener middleware", ->
     expect(@robot.listenerMiddleware).to.have.been.called


### PR DESCRIPTION
Roles are shared, and hence, we can deduplicate results by categorising the subjects by their roles.
